### PR TITLE
Fixes for PhpStorm 2017.3 EAP 173.3188.26 Function.getReturnType()

### DIFF
--- a/src/laravelInsight/fluent/UsingAsTypeInspection.java
+++ b/src/laravelInsight/fluent/UsingAsTypeInspection.java
@@ -6,9 +6,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.jetbrains.php.lang.documentation.phpdoc.psi.PhpDocType;
 import com.jetbrains.php.lang.inspections.PhpInspection;
-import com.jetbrains.php.lang.psi.elements.Function;
-import com.jetbrains.php.lang.psi.elements.Method;
-import com.jetbrains.php.lang.psi.elements.Parameter;
+import com.jetbrains.php.lang.psi.elements.*;
 import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor;
 
 import org.jetbrains.annotations.NotNull;
@@ -31,18 +29,18 @@ public class UsingAsTypeInspection extends PhpInspection {
         return new PhpElementVisitor() {
             @Override
             public void visitPhpMethod(final Method method) {
-                final PsiElement methodReturnType = method.getReturnType();
+                PhpReturnType returnType = method.getReturnType();
+                final ClassReference methodReturnTypeClassReference = returnType!=null ? returnType.getClassReference(): null;
 
-                if (FluentUtil.isUsingDirectly(methodReturnType)) {
-                    problemsHolder.registerProblem(methodReturnType, messageDirectInstantiation, ProblemHighlightType.WEAK_WARNING);
+                if (FluentUtil.isUsingDirectly(methodReturnTypeClassReference)) {
+                    problemsHolder.registerProblem(methodReturnTypeClassReference, messageDirectInstantiation, ProblemHighlightType.WEAK_WARNING);
                 }
             }
 
             @Override
             public void visitPhpFunction(final Function function) {
-                final PsiElement functionReturnType = function.getReturnType();
-
-                if (FluentUtil.isUsingDirectly(functionReturnType)) {
+                final PhpReturnType functionReturnType = function.getReturnType();
+                if (functionReturnType != null && FluentUtil.isUsingDirectly(functionReturnType.getClassReference())) {
                     problemsHolder.registerProblem(functionReturnType, messageDirectInstantiation, ProblemHighlightType.WEAK_WARNING);
                 }
             }

--- a/src/utils/PhpFunctionUtil.java
+++ b/src/utils/PhpFunctionUtil.java
@@ -8,12 +8,7 @@ import com.jetbrains.php.codeInsight.controlFlow.instructions.PhpReturnInstructi
 import com.jetbrains.php.lang.documentation.phpdoc.psi.PhpDocComment;
 import com.jetbrains.php.lang.documentation.phpdoc.psi.tags.PhpDocReturnTag;
 import com.jetbrains.php.lang.lexer.PhpTokenTypes;
-import com.jetbrains.php.lang.psi.elements.ClassReference;
-import com.jetbrains.php.lang.psi.elements.Function;
-import com.jetbrains.php.lang.psi.elements.FunctionReference;
-import com.jetbrains.php.lang.psi.elements.NewExpression;
-import com.jetbrains.php.lang.psi.elements.PhpReference;
-import com.jetbrains.php.lang.psi.elements.PhpTypedElement;
+import com.jetbrains.php.lang.psi.elements.*;
 import com.jetbrains.php.lang.psi.resolve.types.PhpType;
 
 import java.util.Objects;
@@ -28,23 +23,9 @@ public enum PhpFunctionUtil {
     public static PhpType getReturnType(@NotNull final Function functionInitial) {
         final PhpType typeResolved = RecursionResolver.resolve(functionInitial, (RecursionResolver.Resolver resolver) -> {
             final Function   function           = (Function) resolver.getObject();
-            final PsiElement functionReturnType = function.getReturnType();
-
-            if (functionReturnType instanceof PhpReference) {
-                final String                 functionReturnTypeFQN     = ((PhpReference) functionReturnType).getFQN();
-                final PhpType.PhpTypeBuilder functionReturnTypePrimary = PhpType.builder().add(functionReturnTypeFQN);
-
-                final PsiElement prevMatch = TreeUtil.getPrevMatch(
-                    functionReturnType,
-                    filterBy -> (filterBy instanceof ASTNode) && Objects.equals(((ASTNode) filterBy).getElementType(), PhpTokenTypes.opQUEST),
-                    stopBy -> (stopBy instanceof ASTNode) && Objects.equals(((ASTNode) stopBy).getElementType(), PhpTokenTypes.chRPAREN)
-                );
-
-                if (prevMatch instanceof ASTNode) {
-                    functionReturnTypePrimary.add(PhpType.NULL);
-                }
-
-                return functionReturnTypePrimary.build();
+            final PhpReturnType functionReturnType = function.getReturnType();
+            if (functionReturnType != null) {
+                return functionReturnType.getType();
             }
 
             final PhpInstruction[] phpInstructions = function.getControlFlow().getInstructions();

--- a/tests/idea/utils/TreeUtilTest.java
+++ b/tests/idea/utils/TreeUtilTest.java
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiFile;
 import com.jetbrains.php.lang.documentation.phpdoc.psi.PhpDocComment;
 import com.jetbrains.php.lang.lexer.PhpTokenTypes;
 import com.jetbrains.php.lang.psi.elements.Function;
+import com.jetbrains.php.lang.psi.elements.PhpReturnType;
 import org.junit.Assert;
 
 import net.rentalhost.suite.FixtureSuite;
@@ -27,7 +28,8 @@ public class TreeUtilTest extends FixtureSuite {
         ));
 
         final Function   referenceFunction   = (Function) getElementByName(fileSample, "referenceFunction");
-        final PsiElement referenceReturnType = valueOf(referenceFunction.getReturnType());
+        PhpReturnType returnType = referenceFunction.getReturnType();
+        final PsiElement referenceReturnType = valueOf(returnType != null ? returnType.getClassReference() : null);
 
         Assert.assertNull(TreeUtil.getPrevMatch(
             referenceReturnType,


### PR DESCRIPTION
`Function.getReturnType()` now return `PhpReturnType` element for function/method return type. `PhpReturnType.getClassReference()` return `ClassReference` in return type as before and `isNullable()` method returns true if function/method return type has `?` e.g. `function f():?A {}`

These changes fixes plugin according to new behavior. Please, test these changes and apply it